### PR TITLE
'ancestorInheritedElementForWidgetOfExactType' is deprecated and shou…

### DIFF
--- a/lib/src/flutter_restart.dart
+++ b/lib/src/flutter_restart.dart
@@ -15,9 +15,8 @@ class RestartWidget extends StatefulWidget {
     assert(context != null);
 
     return (context
-        .ancestorInheritedElementForWidgetOfExactType(
-        _RestartInheritedWidget)
-        .widget as _RestartInheritedWidget)
+            .getElementForInheritedWidgetOfExactType<_RestartInheritedWidget>()
+            .widget as _RestartInheritedWidget)
         .state;
   }
 }


### PR DESCRIPTION
#### Fix deprecation

```
   info • 'ancestorInheritedElementForWidgetOfExactType' is deprecated and shouldn't be used. Use
          getElementForInheritedWidgetOfExactType instead. This feature was deprecated after v1.12.1. •
          lib/shared/widgets/RestartWidget.dart:17:21 • deprecated_member_use
```